### PR TITLE
Sett lightmode som default

### DIFF
--- a/src/components/utils/DarkModeContainer.tsx
+++ b/src/components/utils/DarkModeContainer.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, PropsWithChildren } from 'react';
 import fetchSunTime from '../../api/suntimeApi';
 import { useQuery } from '@tanstack/react-query';
 import { Loading } from './Loading';
-import { Error } from './Error';
 
 const REFETCH_INTERVAL_HOURS = 8; // how often to refetch sunrise/sunset times
 const CHECK_INTERVAL_MINUTES = 5; // interval to check for dark mode toggle
@@ -43,8 +42,6 @@ export const DarkModeContainer = ({ children }: PropsWithChildren) => {
   }, [data, isError]);
 
   if (isLoading) return <Loading />;
-
-  if (isError) return <Error />;
 
   return (
     <div className={isDarkMode ? 'dark' : ''}>

--- a/src/components/utils/DarkModeContainer.tsx
+++ b/src/components/utils/DarkModeContainer.tsx
@@ -1,4 +1,4 @@
-import {useState, useEffect, PropsWithChildren} from 'react';
+import { useState, useEffect, PropsWithChildren } from 'react';
 import fetchSunTime from '../../api/suntimeApi';
 import { useQuery } from '@tanstack/react-query';
 import { Loading } from './Loading';
@@ -8,7 +8,7 @@ const REFETCH_INTERVAL_HOURS = 8; // how often to refetch sunrise/sunset times
 const CHECK_INTERVAL_MINUTES = 5; // interval to check for dark mode toggle
 
 export const DarkModeContainer = ({ children }: PropsWithChildren) => {
-  const [ isDarkMode, setIsDarkMode ] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
 
   const { isLoading, isError, data } = useQuery({
     queryKey: ['sunTime'],
@@ -18,7 +18,7 @@ export const DarkModeContainer = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     const checkDarkMode = () => {
-      if (data) {
+      if (data && !isError) {
         const now = new Date();
         const sunrise = new Date(data.properties.sunrise.time);
         const sunset = new Date(data.properties.sunset.time);
@@ -29,14 +29,18 @@ export const DarkModeContainer = ({ children }: PropsWithChildren) => {
 
         // Check if current time is after sunset or before sunrise
         setIsDarkMode(now < sunrise || now > sunset);
+      } else {
+        setIsDarkMode(false); // Default to light mode if there's an error or no data
       }
-    }
+    };
 
-    // Check dark mode status every minute
+    // Check dark mode status every CHECK_INTERVAL_MINUTES
     const intervalId = setInterval(checkDarkMode, 1000 * 60 * CHECK_INTERVAL_MINUTES);
 
+    checkDarkMode(); // Check dark mode status immediately on mount
+
     return () => clearInterval(intervalId);
-  }, [data]);
+  }, [data, isError]);
 
   if (isLoading) return <Loading />;
 


### PR DESCRIPTION
Hvis det skjer en feil med API-kallet blir det automatisk satt til lightmode, istedenfor å vise error.