### PR TITLE
Større tittel og tekst

### DIFF
--- a/src/components/cards/BlastCard.tsx
+++ b/src/components/cards/BlastCard.tsx
@@ -23,10 +23,10 @@ export const BlastCard = ({ blast }: { blast: BlastType }) => {
           </div>
         </div>
       </div>
-      <div className="mx-4 mt-3 mb-2 text-xl font-bold dark:text-white">{headerLine}</div>
+      <div className="mx-4 mt-3 mb-2 text-2xl font-bold dark:text-white">{headerLine}</div>
       <div
         ref={contentRef}
-        className="mx-4 mb-2 break-words text-ellipsis dark:text-white line-clamp-3"
+        className="mx-4 mb-2 text-lg break-words text-ellipsis dark:text-white line-clamp-3"
         dangerouslySetInnerHTML={{ __html: formattedText }}
       />
       {isOverflowing && (


### PR DESCRIPTION
Endret størrelse på tekst i blast-kortene. Burde de bli enda større?

Før:
![image](https://github.com/user-attachments/assets/308fa1ca-a4e2-48d8-a2ae-55ef695de430)

Etter:
![image](https://github.com/user-attachments/assets/65e06bb0-f317-4af6-a228-12b7664cd19d)