### PR TITLE
Changed the way slack messages are displayed

### DIFF
--- a/src/components/LatestBlasts.tsx
+++ b/src/components/LatestBlasts.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { BlastType } from "../lib/types";
-import { InfiniteAnimate } from "./utils/InfiniteAnimate";
 import { BlastCard } from "./cards/BlastCard";
 import { fetchBlasts } from "../api/blastsApi";
 import { Loading } from "./utils/Loading";
@@ -8,9 +7,6 @@ import { Error } from "./utils/Error";
 
 const REFETCH_INTERVAL_MINUTES = 15; // how often to refetch blasts from slack
 const AMOUNT_OF_BLASTS = 5; // how many blasts to fetch
-const SPEED = .1; // how fast the blasts should move
-
-const TRAINLENGTH = 3; // how many duplicated blasts-lists to show for the infinite scroll effect
 
 export const LatestBlasts = () => {
   const { isLoading, isError, data } = useQuery({
@@ -27,14 +23,10 @@ export const LatestBlasts = () => {
   )
 
   return (
-    <InfiniteAnimate
-      axis='y'
-      speed={SPEED}
-      trainLength={TRAINLENGTH}
-    >
-      {data?.map((blast: BlastType) => (
-        <BlastCard key={blast.id} blast={blast} />
-      )) || []}
-    </InfiniteAnimate>
+    <div className='my-8 flex flex-col gap-8 overflow-hidden w-max'>
+    {data?.map((blast: BlastType) => (
+      <BlastCard key={blast.id} blast={blast} />
+    )) || []}
+    </div>
   );
 };

--- a/src/components/cards/BlastCard.tsx
+++ b/src/components/cards/BlastCard.tsx
@@ -10,30 +10,32 @@ export const BlastCard = ({ blast }: { blast: BlastType }) => {
 
   return (
     <BaseCard width={1000}>
-      <div className="flex items-center w-full gap-4 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+      <div className='flex px-4 py-3 gap-4'>
         <img
-          className="w-12 h-12 rounded-full"
+          className="w-12 h-12 rounded-lg"
           src={blast.author_image}
           alt={blast.author}
         />
-        <div className="font-medium dark:text-white">
-          <div>{blast.author}</div>
-          <div className="text-gray-500 dark:text-gray-400">
-            {formatSlackDate(blast.date)}
+        <div>
+          <div className="flex gap-2 items-center font-medium dark:text-white">
+            <div className="font-medium">{blast.author}</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              {formatSlackDate(blast.date)}
+            </div>
           </div>
+          <div className="my-2 text-2xl font-bold dark:text-white" dangerouslySetInnerHTML={{ __html: headerLine }} />
+          <div
+            ref={contentRef}
+            className="mb-2 text-lg break-words text-ellipsis dark:text-white line-clamp-5"
+            dangerouslySetInnerHTML={{ __html: formattedText }}
+          />
+          {isOverflowing && (
+            <div className="pt-0 pb-2 text-gray-500 dark:text-white">
+              Les resten på <span className="text-blue-500">#korktavla</span>
+            </div>
+          )}
         </div>
       </div>
-      <div className="mx-4 mt-3 mb-2 text-2xl font-bold dark:text-white" dangerouslySetInnerHTML={{ __html: headerLine }} />
-      <div
-        ref={contentRef}
-        className="mx-4 mb-2 text-lg break-words text-ellipsis dark:text-white line-clamp-3"
-        dangerouslySetInnerHTML={{ __html: formattedText }}
-      />
-      {isOverflowing && (
-        <div className="px-4 pt-0 pb-2 text-gray-500 dark:text-white">
-          Les resten på <span className="text-blue-500">#korktavla</span>
-        </div>
-      )}
     </BaseCard>
   );
 };

--- a/src/components/cards/MemeCard.tsx
+++ b/src/components/cards/MemeCard.tsx
@@ -24,7 +24,7 @@ export const MemeCard = ({ meme }: { meme: MemeType }) => {
     <BaseCard>
       <div className="flex items-center w-full gap-4 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <img
-          className="w-12 h-12 rounded-full"
+          className="w-12 h-12 rounded-lg"
           src={meme.author_image}
           alt={meme.author}
         />

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -36,17 +36,11 @@ export const formatSlackDate = (dateInput: string): string => {
   const yesterday = new Date(now);
   yesterday.setDate(now.getDate() - 1);
 
-  const time = date.toLocaleTimeString('nb-NO', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  });
-
   const isSameDay = (firstDate: Date, secondDate: Date) =>
     firstDate.toDateString() === secondDate.toDateString();
 
-  if (isSameDay(date, now)) return `I dag, ${time}`;
-  if (isSameDay(date, yesterday))return `I går, ${time}`;
+  if (isSameDay(date, now)) return 'I dag';
+  if (isSameDay(date, yesterday))return 'I går';
 
   const diffDays = Math.floor(
     Math.abs(now.getTime() - date.getTime()) / (1000 * 3600 * 24)

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -42,8 +42,11 @@ export const useFormattedSlackText = (text: string) => {
   // Convert shortnames to Unicode emojis
   const unicodeText = joypixels.shortnameToUnicode(htmlEscapedText);
 
+  // Remove unsupported emojis
+  const cleanText = removeUnsupportedEmojis(unicodeText);
+
   // Convert *text* to bold and _text_ to italic using regex
-  const formattedTextWithStyles = unicodeText
+  const formattedTextWithStyles = cleanText
     .replace(/\*(.*?)\*/g, '<strong>$1</strong>') // Bold for *text*
     .replace(/_(.*?)_/g, '<em>$1</em>'); // Italic for _text_
 
@@ -67,3 +70,10 @@ export const useFormattedSlackText = (text: string) => {
 
   return { headerLine, formattedText };
 };
+
+export const removeUnsupportedEmojis = (input: string): string => {
+  // Regular expression to find text-based emoji like :man-surfing:
+  const emojiRegex = /:[a-zA-Z0-9_\-+]+:/g;
+
+  return input.replace(emojiRegex, '');
+}


### PR DESCRIPTION
- Made the slack messages static, so no scrolling. Think this is better and easier to read.
- Made each slack message longer, so more text is displayed before it is cut off.
- Changed the layout of each message to resemble how a message is shown in slack.
- Now removing the emojis that is just raw text (:man-surfing: for example)

Before:
![image](https://github.com/user-attachments/assets/f81999b5-88d8-4fb4-9564-db5c3a27ad57)

After:
![image](https://github.com/user-attachments/assets/593a2039-9224-475a-b932-48fd6f5af06e)