### PR TITLE
Legger til prioritetssystem for sider

### DIFF
--- a/frontend/src/components/pages/MainPage.tsx
+++ b/frontend/src/components/pages/MainPage.tsx
@@ -23,14 +23,10 @@ interface Page extends PageAbstract {
 const preparePageSpecifications = (pages: PageSpecification[]): Page[] => {
   const totalPriority = pages.map(page => page.priority()).reduce((a, b) => a + b, 0)
 
-  return pages.map((page) => {
-    const mappedPage = page as any
-
-    mappedPage.probability = page.priority() / totalPriority
-    delete mappedPage.priority
-
-    return mappedPage
-  }
+  return pages.map(({ priority, ...rest }) => ({
+    ...rest,
+    probability: priority() / totalPriority
+  })
   )
 }
 

--- a/frontend/src/components/pages/MainPage.tsx
+++ b/frontend/src/components/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ReactElement } from 'react';
 import { Header } from '../header/Header';
 import { DarkModeProvider } from '../utils/DarkModeProvider';
 import { OnlineAppBlastPage } from './OnlineAppBlastPage';
@@ -7,35 +7,64 @@ import { EventsPage } from './EventsPage';
 import { SlackPage } from './SlackPage';
 import { VideoPage } from './VideoPage';
 
+interface PageAbstract {
+  component: ReactElement;
+  duration: number;
+}
+
+interface PageSpecification extends PageAbstract {
+  priority: number;
+}
+
+interface Page extends PageAbstract {
+  probability: number;
+}
+
+function preparePageSpecifications(pages: PageSpecification[]): Page[] {
+  const totalPriority = pages.map(page => page.priority).reduce((a, b) => a + b, 0)
+
+  return pages.map((page) => {
+    const mappedPage = page as any
+
+    mappedPage.probability = page.priority / totalPriority
+    delete mappedPage.priority
+
+    return mappedPage
+  }
+  )
+}
+
 export const MainPage = () => {
   // All pages with their respective probabilities and durations in seconds
-  const pages = [
+  const pageSpecifications: PageSpecification[] = [
     {
       component: <EventsPage />,
       duration: 60,
-      probability: 0.40,
+      priority: 4,
     },
     {
       component: <SlackPage />,
       duration: 60,
-      probability: 0.30,
+      priority: 3,
     },
     {
       component: <VideoPage pageDuration={60} />,
       duration: 60,
-      probability: 0.05,
+      priority: 0.5,
     },
     {
       component: <ChristmasPage />,
       duration: 60,
-      probability: 0.10,
+      priority: 1,
     },
     {
       component: <OnlineAppBlastPage />,
       duration: 30,
-      probability: 0.15,
+      priority: 1.5,
     },
   ];
+
+  const pages = preparePageSpecifications(pageSpecifications)
 
   const [currentComponentIndex, setCurrentComponentIndex] = useState(0);
   const [opacity, setOpacity] = useState(1);

--- a/frontend/src/components/pages/MainPage.tsx
+++ b/frontend/src/components/pages/MainPage.tsx
@@ -35,7 +35,7 @@ const preparePageSpecifications = (pages: PageSpecification[]): Page[] => {
 }
 
 export const MainPage = () => {
-  // All pages with their respective probabilities and durations in seconds
+  // All pages with their respective priorities and durations in seconds
   const pageSpecifications: PageSpecification[] = [
     {
       component: <EventsPage />,

--- a/frontend/src/components/pages/MainPage.tsx
+++ b/frontend/src/components/pages/MainPage.tsx
@@ -20,7 +20,7 @@ interface Page extends PageAbstract {
   probability: number;
 }
 
-function preparePageSpecifications(pages: PageSpecification[]): Page[] {
+const preparePageSpecifications = (pages: PageSpecification[]): Page[] => {
   const totalPriority = pages.map(page => page.priority()).reduce((a, b) => a + b, 0)
 
   return pages.map((page) => {

--- a/frontend/src/components/pages/MainPage.tsx
+++ b/frontend/src/components/pages/MainPage.tsx
@@ -13,7 +13,7 @@ interface PageAbstract {
 }
 
 interface PageSpecification extends PageAbstract {
-  priority: number;
+  priority: () => number;
 }
 
 interface Page extends PageAbstract {
@@ -21,12 +21,12 @@ interface Page extends PageAbstract {
 }
 
 function preparePageSpecifications(pages: PageSpecification[]): Page[] {
-  const totalPriority = pages.map(page => page.priority).reduce((a, b) => a + b, 0)
+  const totalPriority = pages.map(page => page.priority()).reduce((a, b) => a + b, 0)
 
   return pages.map((page) => {
     const mappedPage = page as any
 
-    mappedPage.probability = page.priority / totalPriority
+    mappedPage.probability = page.priority() / totalPriority
     delete mappedPage.priority
 
     return mappedPage
@@ -40,27 +40,27 @@ export const MainPage = () => {
     {
       component: <EventsPage />,
       duration: 60,
-      priority: 4,
+      priority: () => 4,
     },
     {
       component: <SlackPage />,
       duration: 60,
-      priority: 3,
+      priority: () => 3,
     },
     {
       component: <VideoPage pageDuration={60} />,
       duration: 60,
-      priority: 0.5,
+      priority: () => 0.5,
     },
     {
       component: <ChristmasPage />,
       duration: 60,
-      priority: 1,
+      priority: () => 1,
     },
     {
       component: <OnlineAppBlastPage />,
       duration: 30,
-      priority: 1.5,
+      priority: () => 1.5,
     },
   ];
 


### PR DESCRIPTION
Hvert komponent har nå en funksjon kalt `priority`, som gir en prioritetsscore, som så brukes til å regne ut `probability`.

Laget det som en funksjon og ikke bare et tall slik at vi kan la Napkom-siden ha større prioritet om kvelden.
På den måten kan vi også løse #178 ved å gjøre slik at funksjonen gir prioritet 0 utenfor sesong.
