### PR TITLE
Slack page spacing

### DIFF
--- a/frontend/src/components/LatestBlasts.tsx
+++ b/frontend/src/components/LatestBlasts.tsx
@@ -25,7 +25,7 @@ export const LatestBlasts = () => {
     );
 
   return (
-    <div className="my-8 flex flex-col gap-8 overflow-hidden w-max">
+    <div className="my-4 flex flex-col gap-4 overflow-hidden w-max">
       {isLoading
         ? [...Array(AMOUNT_OF_BLASTS)].map((_, index) => (
             <BlastCardSkeleton key={index} />

--- a/frontend/src/components/cards/BlastCard.tsx
+++ b/frontend/src/components/cards/BlastCard.tsx
@@ -10,7 +10,7 @@ export const BlastCard = ({ blast }: { blast: BlastType }) => {
   const { contentRef, isOverflowing } = useIsOverflowing(formattedText);
 
   return (
-    <BaseCard width={1000}>
+    <BaseCard width={1250}>
       <div className='flex p-3 gap-4'>
         <img
           className="w-12 h-12 rounded-lg"
@@ -27,14 +27,14 @@ export const BlastCard = ({ blast }: { blast: BlastType }) => {
             </div>
             <Badge color='blue' text={"#" + blast.channel_name} />
           </div>
-          <div className="my-2 text-2xl font-bold dark:text-white" dangerouslySetInnerHTML={{ __html: headerLine }} />
+          <div className="my-1 text-2xl font-bold dark:text-white" dangerouslySetInnerHTML={{ __html: headerLine }} />
           <div
             ref={contentRef}
-            className="mb-2 text-lg break-words text-ellipsis dark:text-white line-clamp-5"
+            className="mb-1 text-lg break-words text-ellipsis dark:text-white line-clamp-5"
             dangerouslySetInnerHTML={{ __html: formattedText }}
           />
           {isOverflowing && (
-            <div className="pt-0 pb-2 text-gray-500 dark:text-white">
+            <div className="text-gray-500 dark:text-white">
               Les resten på <span className="text-blue-500">#{blast.channel_name}</span>
             </div>
           )}

--- a/frontend/src/components/cards/MemeCard.tsx
+++ b/frontend/src/components/cards/MemeCard.tsx
@@ -5,7 +5,7 @@ import { BaseCard } from "./BaseCard";
 import { SlackReaction } from "../SlackReaction";
 import { Badge } from "../Badge";
 
-const WIDTH = 500;
+const WIDTH = 550;
 const MAX_RETRIES = 10;
 
 export const MemeCard = ({ meme }: { meme: MemeType }) => {
@@ -22,7 +22,7 @@ export const MemeCard = ({ meme }: { meme: MemeType }) => {
   };
 
   return (
-    <BaseCard>
+    <BaseCard width={WIDTH}>
       <div className="relative flex items-center w-full gap-4 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <img
           className="w-12 h-12 rounded-lg"
@@ -38,10 +38,7 @@ export const MemeCard = ({ meme }: { meme: MemeType }) => {
         <Badge text={"#" + meme.channel_name} color="blue" className="absolute top-3 right-3" />
       </div>
       {imageError ? (
-        <div
-          className="flex items-center justify-center py-12 bg-white dark:text-white dark:bg-gray-800"
-          style={{ width: `${WIDTH}px` }}
-        >
+        <div className="flex items-center justify-center py-12 bg-white dark:text-white dark:bg-gray-800">
           Oops, her skjedde det en feil :(
         </div>
       ) : (
@@ -49,15 +46,11 @@ export const MemeCard = ({ meme }: { meme: MemeType }) => {
           className="bg-white dark:bg-gray-800 dark:text-white"
           src={`${meme.url}?retry=${retryCount}`}
           alt={`Meme ${meme.url}`}
-          style={{ width: `${WIDTH}px` }}
           onError={handleImageError}
         />
       )}
       {meme.reactions.length > 0 && (
-        <div
-          className='flex justify-start flex-grow w-full gap-2 p-2 overflow-hidden'
-          style={{ width: `${WIDTH}px` }}
-        >
+        <div className='flex justify-start flex-grow w-full gap-2 p-2 overflow-hidden'>
           {meme.reactions.map((reaction, index) => (
             <SlackReaction
               key={index}

--- a/frontend/src/components/pages/SlackPage.tsx
+++ b/frontend/src/components/pages/SlackPage.tsx
@@ -2,9 +2,8 @@ import { LatestBlasts } from "../LatestBlasts"
 import { LatestMemes } from "../LatestMemes"
 
 export const SlackPage = () => (
-  <div className='relative flex justify-between px-28'>
+  <div className='flex justify-around'>
     <LatestMemes />
-    <div className='relative w-1 -mt-10 border-l border-light-grey dark:border-gray-700'></div>
     <LatestBlasts />
   </div>
 )

--- a/frontend/src/components/skeletons/BlastCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/BlastCardSkeleton.tsx
@@ -1,7 +1,7 @@
 import { BaseCard } from "../cards/BaseCard";
 
 export const BlastCardSkeleton = () => (
-  <BaseCard width={1000}>
+  <BaseCard width={1250}>
     <div className='flex p-3 gap-4 animate-pulse'>
       <svg
         className="w-12 h-12 rounded-lg text-gray-200 dark:text-gray-600"

--- a/frontend/src/components/skeletons/MemeCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/MemeCardSkeleton.tsx
@@ -1,7 +1,9 @@
 import { BaseCard } from "../cards/BaseCard";
 
+const WIDTH = 550;
+
 export const MemeCardSkeleton = () => (
-  <BaseCard>
+  <BaseCard width={WIDTH}>
     <div className="relative flex items-center w-full gap-4 px-4 py-3 border-b border-gray-200 dark:border-gray-700 animate-pulse">
       <svg
         className="w-12 h-12 rounded-lg text-gray-200 dark:text-gray-600"
@@ -19,7 +21,7 @@ export const MemeCardSkeleton = () => (
       <div className="h-7 bg-gray-200 rounded-lg dark:bg-gray-700 w-20 absolute top-3 right-3" />
     </div>
     <div className="flex items-center justify-center h-64 bg-gray-300 dark:bg-gray-700 animate-pulse"
-      style={{ width: `500px` }}>
+      style={{ width: WIDTH + 'px' }}>
       <svg className="w-10 h-10 text-gray-200 dark:text-gray-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18">
           <path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"/>
       </svg>


### PR DESCRIPTION
Bruker mer av plasser på slack-siden:
- Gjort både memes og blasts litt bredere
- Gjort teksten litt tettere for blasts
- Litt tettere gap mellom blasts

Før:
![image](https://github.com/user-attachments/assets/df201aa5-052b-4585-bb96-40bf33f0942d)

Etter:
![image](https://github.com/user-attachments/assets/7c9b4aba-16f7-4f2f-936e-79397a16adc2)
