### PR TITLE
Adding check for ongoing events

### DIFF
--- a/frontend/src/components/cards/EventCard.tsx
+++ b/frontend/src/components/cards/EventCard.tsx
@@ -8,6 +8,7 @@ import { removeOWFormatting } from '../../lib/text';
 import { useQuery } from '@tanstack/react-query';
 import { fetchAttendanceByEventId } from '../../api/owApi';
 import { calculateSeatsInfo, selectIndicatorColor, determineTimeBeforeRegistrationOpens, determineStatusText } from '../../lib/event';
+import clsx from 'clsx';
 
 export function EventCard({ event }: { event: IEvent }) {
   const { ingress, title, start_date, event_type, images } = event;
@@ -57,9 +58,10 @@ export function EventCard({ event }: { event: IEvent }) {
     <BaseCard showOverflow>
       {statusText && (
         <div
-          className={`absolute inline-flex items-center justify-center py-0.5 px-2 text-sm font-bold text-white 
-            ${isRegistrationEnded ? 'bg-gray-400' : indicatorColor}
-            border-2 border-white rounded-full -top-2 -end-2 dark:border-gray-900`}
+          className= {clsx(
+            'absolute inline-flex items-center justify-center py-0.5 px-2 text-sm font-bold border-2 border-white text-white rounded-full -top-2 -end-2 dark:border-gray-900',
+            isRegistrationEnded ? 'bg-gray-400' : indicatorColor
+          )}
         >
           {statusText}
         </div>

--- a/frontend/src/components/cards/EventCard.tsx
+++ b/frontend/src/components/cards/EventCard.tsx
@@ -38,26 +38,30 @@ export function EventCard({ event }: { event: IEvent }) {
   const eventColor = EVENT_TYPES[event_type - 1]?.colorName;
 
   const { seatsLeft, percentageFilled } = calculateSeatsInfo(attendanceData);
-  const indicatorColor = selectIndicatorColor(percentageFilled);
+  const indicatorColor = selectIndicatorColor(percentageFilled, event.start_date, event.end_date);
   const registrationEnd = new Date(attendanceData?.registration_end);
   const registrationStart = new Date(attendanceData?.registration_start);
   const isRegistrationEnded = new Date() > registrationEnd;
   const timeBeforeRegistrationOpens = determineTimeBeforeRegistrationOpens(registrationStart);
 
+  const statusText = determineStatusText(
+    isRegistrationEnded,
+    timeBeforeRegistrationOpens,
+    seatsLeft,
+    attendanceData?.number_on_waitlist,
+    event.start_date,
+    event.end_date,
+  );
+
   return (
     <BaseCard showOverflow>
-      {isRegistrationEvent && (
+      {statusText && (
         <div
           className={`absolute inline-flex items-center justify-center py-0.5 px-2 text-sm font-bold text-white 
-            ${isRegistrationEnded ? 'bg-gray-400' : indicatorColor} 
+            ${isRegistrationEnded ? 'bg-gray-400' : indicatorColor}
             border-2 border-white rounded-full -top-2 -end-2 dark:border-gray-900`}
         >
-          {determineStatusText(
-            isRegistrationEnded,
-            timeBeforeRegistrationOpens,
-            seatsLeft,
-            attendanceData?.number_on_waitlist
-          )}
+          {statusText}
         </div>
       )}
 

--- a/frontend/src/lib/event.ts
+++ b/frontend/src/lib/event.ts
@@ -12,7 +12,18 @@ export const calculateSeatsInfo = (attendanceEvent: IEventAttendanceDetails): At
   return { seatsLeft, percentageFilled };
 };
 
-export const selectIndicatorColor = (percentageFilled: number): string => {
+export const selectIndicatorColor = (
+  percentageFilled: number,
+  startDate: string,
+  endDate: string
+): string => {
+  const currentDate = new Date().toISOString();
+
+  // Check if event is ongoing
+  if (currentDate >= startDate && currentDate <= endDate) {
+    return 'bg-red-500';
+  }
+
   if (percentageFilled >= 90) return 'bg-red-500';
   if (percentageFilled >= 75) return 'bg-orange-400';
   return 'bg-green-500';
@@ -32,8 +43,17 @@ export const determineStatusText = (
   isRegistrationEnded: boolean,
   { daysDiff, hoursDiff, minutesDiff }: { daysDiff: number; hoursDiff: number; minutesDiff: number },
   seatsLeft: number,
-  numberOnWaitlist: number
-): string => {
+  numberOnWaitlist: number,
+  start_date: string,
+  end_date: string,
+): string | undefined => {
+  const currentDate = new Date().toISOString();
+
+  // Check if event is ongoing
+  if (currentDate >= start_date && currentDate <= end_date) {
+    return 'Pågående';
+  }
+
   if (daysDiff > 0) {
     return `Påmelding åpner om ${daysDiff} ${daysDiff === 1 ? 'dag' : 'dager'}`;
   } else if (hoursDiff > 0) {
@@ -47,5 +67,10 @@ export const determineStatusText = (
   } else if (numberOnWaitlist > 0) {
     return `${numberOnWaitlist} på venteliste`;
   }
-  return `${seatsLeft} ${seatsLeft === 1 ? 'plass' : 'plasser'} igjen`;
+
+  if (seatsLeft > 0) {
+    return `${seatsLeft} ${seatsLeft === 1 ? 'plass' : 'plasser'} igjen`;
+  }
+
+  return undefined;
 };

--- a/frontend/src/lib/event.ts
+++ b/frontend/src/lib/event.ts
@@ -21,7 +21,7 @@ export const selectIndicatorColor = (
 
   // Check if event is ongoing
   if (currentDate >= startDate && currentDate <= endDate) {
-    return 'bg-red-500';
+    return 'bg-amber-200 text-amber-800';
   }
 
   if (percentageFilled >= 90) return 'bg-red-500';


### PR DESCRIPTION
La til "pågående"-badge på arrangementer som er pågående

Gjørt det kanskje litt lettere å skjønne hvorfor arrangementer som har startet for en stund siden fortsatt vises?

![image](https://github.com/user-attachments/assets/1cb7d8f7-b6d7-4c5a-a0e2-9bc215265491)

Kan evt vurdere å filtrere ut disse arrangementene da, å kun vise de som enda ikke har begynt?